### PR TITLE
Update site URL and show avg salary by company

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <img src="./assets/leetcomp_banner.png">
-<sub>https://sidverma.github.io/compensation-analyser</sub>
+<sub>https://sidverma32.github.io/compensation-analyser/</sub>
 </p>
 
 <p align="center">
@@ -9,7 +9,7 @@
 <a href="http://mypy-lang.org/"><img src="http://www.mypy-lang.org/static/mypy_badge.svg" alt="Checked with mypy" /></a>
 </p>
 
-**[Compensation Analyzer](https://sidverma.github.io/compensation-analyser)** is a tool that helps you find **Software Engineer Salary in India** by:
+**[Compensation Analyzer](https://sidverma32.github.io/compensation-analyser/)** is a tool that helps you find **Software Engineer Salary in India** by:
 - Fetching compensation data from Leetcode forums.
 - Updating Bi-weekly through GitHub action PRs.
 - Using LLMs for parsing and sanitizing structured data from posts, followed by aggregation.

--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
             <div id="companyBoxPlot" class="col-12 col-md-8 chart-container"></div>
             <div id="companyBarPlot" class="col-12 col-md-4 chart-container"></div>
         </div>
+        <div class="row">
+            <div id="avgCompanyBarPlot" class="col-12 chart-container"></div>
+        </div>
         <div id="statsStr" class="row m-0 mt-3 p-2 border-top border-bottom bg-light justify-content-center">
         </div>
         <div class="row mt-3">

--- a/script.js
+++ b/script.js
@@ -385,6 +385,50 @@ function sortAndSliceData(companyCounts) {
     return [categories, counts];
 }
 
+function averageSalaryByCompany(jsonData) {
+    const companyTotals = {};
+    jsonData.forEach(({ company, total }) => {
+        if (!companyTotals[company]) {
+            companyTotals[company] = [];
+        }
+        companyTotals[company].push(total);
+    });
+
+    const avgData = Object.entries(companyTotals)
+        .map(([comp, totals]) => ({
+            name: comp,
+            avg:
+                totals.reduce((acc, val) => acc + val, 0) /
+                totals.length,
+        }))
+        .sort((a, b) => b.avg - a.avg)
+        .slice(0, 10);
+
+    const categories = avgData.map((d) => d.name);
+    const averages = avgData.map((d) => parseFloat(d.avg.toFixed(2)));
+
+    Highcharts.chart("avgCompanyBarPlot", {
+        chart: { type: "bar" },
+        title: { text: "" },
+        xAxis: { categories: categories, title: { text: null } },
+        yAxis: {
+            min: 0,
+            title: { text: "Avg ₹ LPA", align: "high" },
+            labels: { overflow: "justify" },
+        },
+        tooltip: { valueSuffix: " LPA" },
+        plotOptions: { bar: { dataLabels: { enabled: true } } },
+        legend: { enabled: false },
+        series: [
+            {
+                name: "Avg Total",
+                data: averages,
+                color: "#3478f6",
+            },
+        ],
+    });
+}
+
 document.addEventListener('DOMContentLoaded', async function () {
 
     async function fetchOffers() {
@@ -402,6 +446,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     setStatsStr(filteredOffers);
     plotHistogram(filteredOffers, 'total');
     mostOfferCompanies(filteredOffers);
+    averageSalaryByCompany(filteredOffers);
     plotBoxPlot(filteredOffers, 'total', 'companyBoxPlot', 'company', new Set([]));
     plotBoxPlot(filteredOffers, 'total', 'yoeBucketBoxPlot', 'mapped_yoe', validYoeBucket);
 
@@ -461,6 +506,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         setStatsStr(filteredOffers);
         plotHistogram(filteredOffers, 'total');
         mostOfferCompanies(filteredOffers);
+        averageSalaryByCompany(filteredOffers);
         plotBoxPlot(filteredOffers, 'total', 'companyBoxPlot', 'company', new Set([]));
         plotBoxPlot(filteredOffers, 'total', 'yoeBucketBoxPlot', 'mapped_yoe', validYoeBucket);
         displayOffers(currentPage);


### PR DESCRIPTION
## Summary
- switch README links to the new GitHub pages URL
- add a new `avgCompanyBarPlot` container in the webpage
- plot an average salary bar chart by company via `averageSalaryByCompany`

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68847f172c74832ba72446e1c09f965b