### PR TITLE
Add basic AI assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ uv pip install -r requirements.txt  # Install from a requirements.txt file.
 $ export PYTHONPATH=.
 $ python leetcomp/refresh.py && python leetcomp/parse.py
 ```
+## Assistant
+
+Run the Flask assistant server to enable the floating chat widget.
+
+```bash
+uv pip install -r requirements.txt
+python assistant.py
+```
+
+Ensure your OpenRouter API key is available as an environment variable
+`OPENROUTER_API_KEY` or in a `.env` file before starting the server.
+
+
 
 ## Roadmap
 

--- a/assistant.py
+++ b/assistant.py
@@ -1,0 +1,24 @@
+from flask import Flask, request, jsonify
+
+from leetcomp.utils import config, get_model_predict
+
+app = Flask(__name__)
+
+predict = get_model_predict(config["app"]["llm_predictor"])
+
+
+@app.route("/api/ask", methods=["POST"])
+def ask():
+    data = request.get_json(silent=True) or {}
+    message = data.get("message", "").strip()
+    if not message:
+        return jsonify({"error": "No message provided"}), 400
+    try:
+        reply = predict(message)
+        return jsonify({"reply": reply})
+    except Exception as e:  # pragma: no cover - runtime safety
+        return jsonify({"error": str(e)}), 500
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/index.html
+++ b/index.html
@@ -41,10 +41,45 @@
     .custom-input-width {
         width: 60px;
     }
-
     .chart-container {
         min-height: 320px;
         height: 45vh;
+    }
+    .fab {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        background-color: #3478f6;
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        z-index: 1000;
+    }
+    .assistant-panel {
+        display: none;
+        position: fixed;
+        bottom: 80px;
+        right: 20px;
+        width: 300px;
+        max-height: 400px;
+        background-color: #ffffff;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 10px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        overflow-y: auto;
+        z-index: 1000;
+    }
+    .assistant-message {
+        margin-bottom: 8px;
+    }
+    .assistant-message.user {
+        text-align: right;
     }
 </style>
 
@@ -174,6 +209,14 @@
             </div>
         </div>
         <div id="offersTable"></div>
+        <div id="assistantPanel" class="assistant-panel">
+            <div id="assistantChat"></div>
+            <div class="input-group mt-2">
+                <input type="text" id="assistantInput" class="form-control form-control-sm" placeholder="Ask a question">
+                <button class="btn btn-primary btn-sm" id="assistantSend">Send</button>
+            </div>
+        </div>
+        <div id="assistantFab" class="fab">🤖</div>
     </div>
 
     <script>

--- a/leetcomp/utils.py
+++ b/leetcomp/utils.py
@@ -31,9 +31,13 @@ def ollama_predict(prompt: str) -> str:
 
 
 def openrouter_predict(prompt: str) -> str:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:  # pragma: no cover - runtime safety
+        raise RuntimeError("OPENROUTER_API_KEY not set")
+
     response = requests.post(
         url=config["llms"]["openrouter_url"],
-        headers={"Authorization": f"Bearer {os.environ['OPENROUTER_API_KEY']}"},
+        headers={"Authorization": f"Bearer {api_key}"},
         data=json.dumps(
             {
                 "model": config["llms"]["openrouter_model"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ typing-extensions==4.12.2
 urllib3==2.2.1
 uv==0.2.5
 virtualenv==20.26.2
+Flask==3.0.2

--- a/script.js
+++ b/script.js
@@ -832,4 +832,43 @@ document.addEventListener('DOMContentLoaded', async function () {
             filterOffersByCompany(searchInput);
         }
     });
+    document.getElementById("assistantFab").addEventListener("click", () => {
+        const panel = document.getElementById("assistantPanel");
+        panel.style.display = panel.style.display === "block" ? "none" : "block";
+    });
+
+    document.getElementById("assistantSend").addEventListener("click", sendAssistantMessage);
+    document.getElementById("assistantInput").addEventListener("keypress", (e) => {
+        if (e.key === "Enter") {
+            sendAssistantMessage();
+        }
+    });
+
+    function appendAssistantMessage(role, text) {
+        const chat = document.getElementById("assistantChat");
+        const div = document.createElement("div");
+        div.className = `assistant-message ${role}`;
+        div.textContent = text;
+        chat.appendChild(div);
+        chat.scrollTop = chat.scrollHeight;
+    }
+
+    async function sendAssistantMessage() {
+        const input = document.getElementById("assistantInput");
+        const text = input.value.trim();
+        if (!text) return;
+        appendAssistantMessage("user", text);
+        input.value = "";
+        try {
+            const resp = await fetch("/api/ask", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ message: text })
+            });
+            const data = await resp.json();
+            appendAssistantMessage("bot", data.reply || data.error || "Error");
+        } catch (err) {
+            appendAssistantMessage("bot", "Error: " + err.message);
+        }
+    }
 });


### PR DESCRIPTION
## Summary
- add a simple Flask server for AI queries
- integrate floating assistant button and chat panel
- wire client JS to `/api/ask`
- document how to run the assistant
- update requirements with Flask
- read `OPENROUTER_API_KEY` from env and mention it in README

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68848dd6959c832b86d024be7a5e1162