### PR TITLE
Fix deep chat initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
         <deep-chat id="chatBot" style="position: fixed; bottom: 20px; right: 20px;"></deep-chat>
     </div>
 
-    <script src="https://unpkg.com/deep-chat@2.2.2/dist/deepChat.bundle.js"></script>
+    <script type="module" src="https://unpkg.com/deep-chat@2.2.2/dist/deepChat.bundle.js"></script>
     <script>
         const chatBot = document.getElementById('chatBot');
         chatBot.directConnection = { openAI: { apiKey: window.OPENAI_API_KEY } };


### PR DESCRIPTION
## Summary
- ensure `deepChat.bundle.js` is loaded as a module

## Testing
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_6884b4294eb8832b8700f0474564056d