### PR TITLE
Configure Deep Chat to use WebLLM

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,10 +174,14 @@
             </div>
         </div>
         <div id="offersTable"></div>
-        <deep-chat id="chatBot" style="position: fixed; bottom: 20px; right: 20px;"></deep-chat>
+        <deep-chat id="chatBot" style="position: fixed; bottom: 20px; right: 20px;" webModel="true"></deep-chat>
     </div>
 
     <script type="module" src="https://unpkg.com/deep-chat@2.2.2/dist/deepChat.bundle.js"></script>
+    <script type="module">
+        import * as webLLM from 'deep-chat-web-llm';
+        window.webLLM = webLLM;
+    </script>
     <script>
         const chatBot = document.getElementById('chatBot');
         chatBot.directConnection = { openAI: { apiKey: window.OPENAI_API_KEY } };


### PR DESCRIPTION
## Summary
- enable WebLLM support for the embedded deep-chat bot

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6884b61d0fbc832ba8720c79eed2b199