### PR TITLE
Fix webLLM import path

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
 
     <script type="module" src="https://unpkg.com/deep-chat@2.2.2/dist/deepChat.bundle.js"></script>
     <script type="module">
-        import * as webLLM from 'deep-chat-web-llm';
+        import * as webLLM from 'https://unpkg.com/deep-chat-web-llm?module';
         window.webLLM = webLLM;
     </script>
     <script>


### PR DESCRIPTION
## Summary
- correct import path for `deep-chat-web-llm` in `index.html`

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6884be27720c832bb58e10a72d311fba